### PR TITLE
Replacing long list of datastream params with a FedoraContent class

### DIFF
--- a/fcrepo-client/src/main/java/org/fcrepo/client/FedoraContent.java
+++ b/fcrepo-client/src/main/java/org/fcrepo/client/FedoraContent.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.client;
+
+import java.io.InputStream;
+import java.net.URI;
+
+/**
+ * Container for holding properties of datastream content.  All setters return the updated object so they can be
+ * chained:
+ * <pre>{@code FedoraContent ds = new FedoraContent().setContent(in).setFilename(filename);}</pre>
+ *
+ * @author escowles
+ * @since 2014-08-08
+**/
+public class FedoraContent {
+
+    private InputStream content;
+    private String contentType;
+    private String filename;
+    private URI checksum;
+
+    /**
+     * Default constructor.
+    **/
+    public FedoraContent() {
+    }
+
+    /**
+     * Get the content stream.
+    **/
+    public InputStream getContent() {
+        return content;
+    }
+
+    /**
+     * Get the content type (MIME type) of the content.
+    **/
+    public String getContentType() {
+        return contentType;
+    }
+
+    /**
+     * Get the original filename of the content source file.
+    **/
+    public String getFilename() {
+        return filename;
+    }
+
+    /**
+     * Get the SHA-1 checksum of the content as a URI (e.g.,
+     * "{@code urn:sha1:290fa4c6a6161c0941fcaa915e2f96aecc85cd9f}").
+    **/
+    public URI getChecksum() {
+        return checksum;
+    }
+
+    /**
+     * Set the content stream.
+     * @return The updated object for chaining.
+    **/
+    public FedoraContent setContent( final InputStream content ) {
+        this.content = content;
+        return this;
+    }
+
+    /**
+     * Set the content type (MIME type) of the content.
+     * @return The updated object for chaining.
+    **/
+    public FedoraContent setContentType( final String contentType ) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    /**
+     * Set the filename of the content source file.
+     * @return The updated object for chaining.
+    **/
+    public FedoraContent setFilename( final String filename ) {
+        this.filename = filename;
+        return this;
+    }
+
+    /**
+     * Set the checksum of the content as a URI (e.g.,
+     * "{@code urn:sha1:290fa4c6a6161c0941fcaa915e2f96aecc85cd9f}").
+     * @return The updated object for chaining.
+    **/
+    public FedoraContent setChecksum( final URI checksum ) {
+        this.checksum = checksum;
+        return this;
+    }
+
+}

--- a/fcrepo-client/src/main/java/org/fcrepo/client/FedoraDatastream.java
+++ b/fcrepo-client/src/main/java/org/fcrepo/client/FedoraDatastream.java
@@ -68,11 +68,7 @@ public interface FedoraDatastream extends FedoraResource {
 
     /**
      * Replace the content of this Datastream.
-     * @param content New datastream content.
-     * @param contentType Content type (MIME type) of the new content.
-     * @param filename Filename of the new content.
-     * @param checksum Checksum of the new content.
+     * @param content Updated content of the datastream.
     **/
-    public void updateContent( InputStream content, String contentType, String filename, URI checksum )
-            throws ReadOnlyException;
+    public void updateContent( FedoraContent content ) throws ReadOnlyException;
 }

--- a/fcrepo-client/src/main/java/org/fcrepo/client/FedoraRepository.java
+++ b/fcrepo-client/src/main/java/org/fcrepo/client/FedoraRepository.java
@@ -17,7 +17,6 @@
 package org.fcrepo.client;
 
 import java.io.InputStream;
-import java.net.URI;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -51,16 +50,9 @@ public interface FedoraRepository {
     /**
      * Create a new Datastream.
      * @param path The path of the new datastream.
-     * @param content The datastream content as an InputStream.
-     * @param contentType The content type (MIME type) of the new datastream content.
-     * @param filename The filename of the new datastream content.
-     * @param checksum The checksum of the new datastream content.
+     * @param content Content of the new datastream.
     **/
-    public FedoraDatastream createDatastream(String path,
-                                             InputStream content,
-                                             String contentType,
-                                             String filename,
-                                             URI checksum) throws ReadOnlyException;
+    public FedoraDatastream createDatastream( String path, FedoraContent content ) throws ReadOnlyException;
 
     /**
      * Create a new Object.

--- a/fcrepo-client/src/test/java/org/fcrepo/client/FedoraContentTest.java
+++ b/fcrepo-client/src/test/java/org/fcrepo/client/FedoraContentTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.Test;
+
+/**
+ * Test of FedoraContet.
+ * @author escowles
+ * @since 2014-08-08
+**/
+public class FedoraContentTest {
+
+    @Test
+    public void testFedoraContent() throws URISyntaxException {
+        final InputStream in = new ByteArrayInputStream("foo".getBytes());
+        final String contentType = "text/plain";
+        final String filename = "foo.txt";
+        final URI checksum = new URI("urn:sha1:0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33");
+
+        final FedoraContent content = new FedoraContent();
+        content.setContent(in);
+        content.setContentType(contentType);
+        content.setFilename(filename);
+        content.setChecksum(checksum);
+
+        assertEquals( in, content.getContent() );
+        assertEquals( contentType, content.getContentType() );
+        assertEquals( filename, content.getFilename() );
+        assertEquals( checksum, content.getChecksum() );
+    }
+
+    @Test
+    public void testFedoraContentChain() throws URISyntaxException {
+        final ByteArrayInputStream in = new ByteArrayInputStream("foo".getBytes());
+        final String contentType = "text/plain";
+        final String filename = "foo.txt";
+        final URI checksum = new URI("urn:sha1:0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33");
+
+        final FedoraContent content = new FedoraContent().setContent(in).setContentType(contentType)
+                .setFilename(filename).setChecksum(checksum);
+
+        assertEquals( in, content.getContent() );
+        assertEquals( contentType, content.getContentType() );
+        assertEquals( filename, content.getFilename() );
+        assertEquals( checksum, content.getChecksum() );
+    }
+}


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/76595254
