### PR TITLE
explicitly define package import/exports

### DIFF
--- a/fcrepo-client/pom.xml
+++ b/fcrepo-client/pom.xml
@@ -13,6 +13,12 @@
 
   <properties>
     <jena.version>2.12.1</jena.version>
+    <osgi.import.packages>
+      *
+    </osgi.import.packages>
+    <osgi.export.packages>
+      org.fcrepo.client;version=${project.version}
+    </osgi.export.packages>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This commit: https://github.com/fcrepo4/fcrepo4/commit/f12da9eecb85cec7be1aa3a94f2735c1cd238387 is causing fcrepo4-client to fail because the package imports and exports are not being explicitly defined. This PR defines those values.