### PR TITLE
FCREPO-1443 fcrepo-client should use Link rel="describedby" header for description

### DIFF
--- a/fcrepo-client-impl/pom.xml
+++ b/fcrepo-client-impl/pom.xml
@@ -89,6 +89,16 @@
       <type>war</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+      <version>2.22.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/fcrepo-client-impl/src/main/java/org/fcrepo/client/impl/FedoraResourceImpl.java
+++ b/fcrepo-client-impl/src/main/java/org/fcrepo/client/impl/FedoraResourceImpl.java
@@ -16,6 +16,7 @@
 package org.fcrepo.client.impl;
 
 import static org.apache.http.HttpStatus.SC_CONFLICT;
+import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
@@ -412,7 +413,7 @@ public class FedoraResourceImpl implements FedoraResource {
             final StatusLine status = response.getStatusLine();
             final String uri = postVersion.getURI().toString();
 
-            if ( status.getStatusCode() == SC_NO_CONTENT) {
+            if ( status.getStatusCode() == SC_CREATED) {
                 LOGGER.debug("new version created for resource at {}", uri);
             } else if ( status.getStatusCode() == SC_CONFLICT) {
                 LOGGER.debug("The label {} is in use by another version.", label);

--- a/fcrepo-client-impl/src/test/java/org/fcrepo/client/impl/FedoraResourceImplTest.java
+++ b/fcrepo-client-impl/src/test/java/org/fcrepo/client/impl/FedoraResourceImplTest.java
@@ -190,7 +190,7 @@ public class FedoraResourceImplTest {
         final HttpPost post = new HttpPost(repositoryURL);
         when(mockHelper.execute(any(HttpPost.class))).thenReturn(mockResponse);
         when(mockResponse.getStatusLine()).thenReturn(mockStatus);
-        when(mockStatus.getStatusCode()).thenReturn(204);
+        when(mockStatus.getStatusCode()).thenReturn(201);
         when(mockHelper.createPostMethod(anyString(), any(Map.class))).thenReturn(post);
         final String label = "examplelabel";
         resource.createVersionSnapshot(label);

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <logback.version>1.0.13</logback.version>
     <slf4j.version>1.7.7</slf4j.version>
     <fcrepo-buildtools.version>4.3.0</fcrepo-buildtools.version>
-    <checkstyle.plugin.version>2.12.1</checkstyle.plugin.version>
+    <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
There were several possible approaches to this problem, and I have attempted to resolve this in the following manner:

When retrieving the URI path for Datastreams of non-RDF resources, a HEAD request must be passed against the resource in order to determine whether or not the "Link" header is passed in the response, and, (if it is) to identify the URI for the linked resource containing the metadata for the resource.

Please let me know if this is not the most efficient manner of attempting to identify the linked metadata resource (i. e. should I not be transmitting a HEAD request), and I shall work to implement a more optimized solution.