### PR TITLE
Issue37 createVersionSnapshot  may return a NO_CONTENT status

### DIFF
--- a/fcrepo-client-impl/src/main/java/org/fcrepo/client/impl/FedoraResourceImpl.java
+++ b/fcrepo-client-impl/src/main/java/org/fcrepo/client/impl/FedoraResourceImpl.java
@@ -413,7 +413,7 @@ public class FedoraResourceImpl implements FedoraResource {
             final StatusLine status = response.getStatusLine();
             final String uri = postVersion.getURI().toString();
 
-            if ( status.getStatusCode() == SC_CREATED) {
+            if ( status.getStatusCode() == SC_CREATED || status.getStatusCode() == SC_NO_CONTENT) {
                 LOGGER.debug("new version created for resource at {}", uri);
             } else if ( status.getStatusCode() == SC_CONFLICT) {
                 LOGGER.debug("The label {} is in use by another version.", label);


### PR DESCRIPTION
I'm currently working for the university of Geneva. They are using Fedora3 and want to migrate to Fedora4. I've tried running the migration-utils tool but got errors each time it tried to create an fcr:versions subpage because the creation of such a page returned NO_CONTENT.
I've changed the FedoraRessourceImpl code so that is does not throw an exception in such a case.
Hope you agree with this.
Thanks